### PR TITLE
ci: update to Vault 1.6.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         vault-version:
-        - 1.6.2
+        - 1.6.3
         - 1.5.7
         - 1.4.7
     env:


### PR DESCRIPTION
- https://github.com/hashicorp/vault/releases/tag/v1.6.3