### PR TITLE
ci: update to Vault 1.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     strategy:
       matrix:
         vault-version:
+        - 1.7.0
         - 1.6.3
         - 1.5.7
         - 1.4.7


### PR DESCRIPTION
https://github.com/hashicorp/vault/releases/tag/v1.7.0